### PR TITLE
Return mocha runner exit status for  task

### DIFF
--- a/lib/bin/bozon.js
+++ b/lib/bin/bozon.js
@@ -23,7 +23,9 @@ program
   .command('test [spec]')
   .description('Run tests from spec/ directory')
   .action(function (spec) {
-    runner.test(spec)
+    runner.test(spec).then(function(result) {
+      process.exit(result.status);
+    })
   })
 
 program

--- a/lib/bin/runner.js
+++ b/lib/bin/runner.js
@@ -22,7 +22,7 @@ var runner = {
   },
 
   test: function (args) {
-    new SpecRunner(args).run()
+    return new SpecRunner(args).run()
   }
 }
 

--- a/lib/testing/spec_runner.js
+++ b/lib/testing/spec_runner.js
@@ -54,17 +54,19 @@ var SpecRunner = (function () {
 
     return {
       run: function () {
-        if (shouldPackageApp()) {
-          var packager = new Packager(_this.settings.platform(), 'test')
-          packager.build().then(function () {
-            console.log()
-            bozon.runMocha(mochaOptions())
-          }).catch(function (err) {
-            console.log(err)
-          })
-        } else {
-          bozon.runMocha(mochaOptions())
-        }
+        return new Promise(function (resolve) {
+          if (shouldPackageApp()) {
+            var packager = new Packager(_this.settings.platform(), 'test')
+            packager.build().then(function () {
+              console.log()
+              resolve(bozon.runMocha(mochaOptions()))
+            }).catch(function (err) {
+              console.log(err)
+            })
+          } else {
+            resolve(bozon.runMocha(mochaOptions()))
+          }
+        });
       }
     }
   }

--- a/lib/utils/bozon.js
+++ b/lib/utils/bozon.js
@@ -55,7 +55,7 @@ var bozon = {
   },
 
   spawnSync: function (command, options) {
-    childProcess.spawnSync(command, options, {
+    return childProcess.spawnSync(command, options, {
       shell: true,
       stdio: 'inherit'
     })

--- a/test/lib/testing/spec_runner_spec.coffee
+++ b/test/lib/testing/spec_runner_spec.coffee
@@ -21,9 +21,9 @@ describe 'SpecRunner', ->
       SpecRunner = require '../../../lib/testing/spec_runner'
 
     describe 'no arguments', ->
-      beforeEach ->
+      beforeEach (done) ->
         runner = new SpecRunner()
-        runner.run()
+        runner.run().then(() -> done())
 
       it 'should package test app and run mocha', (done) ->
         expect(packagerSpy.calledOnce).to.eq(true)
@@ -192,3 +192,46 @@ describe 'SpecRunner', ->
           expect(mochaSpy.getCall(9).args).to.eql([['--recursive', path.join(process.cwd(), 'spec'), '--compilers', 'ts:typescript-require', 'coffee:coffee-script/register']])
           done()
         , 0
+
+  describe 'Spec runner exit code', ->
+    mochaSpy = sinon.stub().returns({status: 321})
+    runResult = {}
+
+    beforeEach =>
+      mockRequire '../../../lib/packaging/packager', packagerSpy
+      mockRequire '../../../lib/utils/bozon',
+        runMocha: mochaSpy
+      mockRequire '../../../lib/testing/utils',
+        uniqFileExtensions: sinon.stub().returns(['ts', 'js', 'coffee'])
+      SpecRunner = reload '../../../lib/testing/spec_runner'
+
+    describe 'no arguments', ->
+      beforeEach ->
+        runner = new SpecRunner()
+          .run().then((result) -> runResult = result)
+
+      it 'should resolve exit code', (done) ->
+        setTimeout ->
+          expect(runResult).to.deep.eq({status: 321})
+          done()
+
+    describe 'unit spec file', =>
+      beforeEach ->
+        runner = new SpecRunner('spec/units/some_unit_spec.js')
+          .run().then((result) -> runResult = result)
+
+      it 'should resolve exit code', (done) ->
+        setTimeout ->
+          expect(runResult).to.deep.eq({status: 321})
+          done()
+
+    describe 'feature spec file', =>
+      beforeEach ->
+        runner = new SpecRunner('spec/features/some_feature_spec.js')
+          .run().then((result) -> runResult = result)
+
+      it 'should resolve exit code', (done) ->
+        setTimeout ->
+          expect(runResult).to.deep.eq({status: 321})
+          done()
+


### PR DESCRIPTION
### Description
`bozon test` task always return `0` exit code (even when tests fail).
The reason is that we run mocha specs with `childProcess.spawnSync` and do not check child process status.

### Changes
- added [return Object](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options) for `bozon.spawnSync` method 
- setting process exit status for `test` task same as mocha runner status
- added specs