### PR TITLE
Add run command

### DIFF
--- a/lib/bin/bozon.js
+++ b/lib/bin/bozon.js
@@ -43,5 +43,12 @@ program
     runner.package(platform)
   })
 
+program
+  .command('run <task>')
+  .description('Run the defined task')
+  .action(function (task) {
+    runner.run(task)
+  })
+
 
 program.parse(process.argv)

--- a/lib/bin/runner.js
+++ b/lib/bin/runner.js
@@ -1,8 +1,9 @@
-var Generator  = require('./../scaffolding/generator')
-var Starter    = require('./../starting/starter')
-var Packager   = require('./../packaging/packager')
-var Cleaner    = require('./../clearing/cleaner')
-var SpecRunner = require('./../testing/spec_runner')
+var Generator   = require('./../scaffolding/generator')
+var Starter     = require('./../starting/starter')
+var Packager    = require('./../packaging/packager')
+var Cleaner     = require('./../clearing/cleaner')
+var SpecRunner  = require('./../testing/spec_runner')
+var TaskStarter = require('./../starting/task_starter')
 
 var runner = {
   new: function (name) {
@@ -23,6 +24,10 @@ var runner = {
 
   test: function (args) {
     return new SpecRunner(args).run()
+  },
+
+  run: function (task) {
+    new TaskStarter(task).run();
   }
 }
 

--- a/lib/running/task_runner.js
+++ b/lib/running/task_runner.js
@@ -1,0 +1,22 @@
+var bozon = require('../bozon')
+
+var Runner = (function () {
+  function Runner (platform, environment, task) {
+    this.platform = platform
+    this.environment = environment
+		this.task = task
+  }
+
+  Runner.prototype.run = function () {
+		bozon.runGulp([
+      this.task,
+      '--platform=' + this.platform,
+      '--env=' + this.environment
+    ])
+  }
+
+  return Runner
+}
+)()
+
+module.exports = Runner

--- a/lib/starting/task_starter.js
+++ b/lib/starting/task_starter.js
@@ -1,0 +1,20 @@
+var bozon = require('../bozon')
+var Checker = require('../utils/checker')
+var Runner = require('../running/task_runner.js')
+
+var TaskStarter = (function () {
+  function TaskStarter (task) {
+    Checker.ensure()
+    this.env = 'development'
+    this.settings = new bozon.Settings()
+    this.task = task
+  }
+
+  TaskStarter.prototype.run = function () {
+    new Runner(this.settings.platform(), this.env, this.task).run()
+  }
+  return TaskStarter
+}
+)()
+
+module.exports = TaskStarter


### PR DESCRIPTION
For running tasks that don't fit within bozon

Allows for running bozon differently, such as running a livereload or some other commands. 

Future plans include adding another optional parameter to the start command, allowing for running other optional tasks within and then starting electron. 

These changes hopefully make it easy to setup livereload within bozon if needed.

I tried to follow the style of the repo, but I probably messed up some of the naming, so I'll fix anything you want fixed.