### PR TITLE
Allow multiple strings through bozon.src calls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+  
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+quote_type = single
+
+[*.md]
+trim_trailing_whitespace = false

--- a/lib/utils/bozon.js
+++ b/lib/utils/bozon.js
@@ -16,7 +16,13 @@ var bozon = {
   },
 
   src: function (suffix) {
-    return this.requireLocal('gulp').src(this.sourcePath(suffix))
+    var sources;
+    if (Array.isArray(suffix)) {
+      sources = suffix.map(this.sourcePath.bind(this))
+    } else {
+      sources = this.sourcePath(suffix)
+    }
+    return this.requireLocal('gulp').src(sources)
   },
 
   dest: function (suffix) {

--- a/test/lib/utils/bozon_spec.coffee
+++ b/test/lib/utils/bozon_spec.coffee
@@ -27,12 +27,20 @@ describe '#bozon', ->
       expect(gulpTaskSpy.getCall(0).args[0]).to.eq('compile')
 
   describe '#src', ->
-    beforeEach =>
-      bozon.src('javascripts')
+    afterEach =>
+      gulpSrcSpy.reset()
 
     it 'should set gulp src', =>
+      bozon.src('javascripts')
       expect(gulpSrcSpy.calledOnce).to.be.true
       expect(gulpSrcSpy.getCall(0).args[0]).to.eq("#{process.cwd()}/app/javascripts")
+
+    it 'should set multiple gulp sources', =>
+      bozon.src(['javascripts', 'styles'])
+      expect(gulpSrcSpy.calledOnce).to.be.true
+      expect(gulpSrcSpy.getCall(0).args[0]).to.instanceof(Array)
+      expect(gulpSrcSpy.getCall(0).args[0][0]).to.eq("#{process.cwd()}/app/javascripts")
+      expect(gulpSrcSpy.getCall(0).args[0][1]).to.eq("#{process.cwd()}/app/styles")
 
   describe '#dest', ->
     beforeEach =>


### PR DESCRIPTION
This enhancement allows the `bozon.src` to pass additional glob patterns to `gulp.src`.

I also added an `.editorconfig` file as an editor convenience.