### PR TITLE
introspect error object

### DIFF
--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -7,7 +7,7 @@ import { bundle } from 'builder/bundle'
 import { watch } from 'builder/watcher'
 import { source, sourcePath, destinationPath } from 'utils'
 import { log, warn, startSpinner, stopSpinner } from 'utils/logger'
-import * as Util from "node/util";
+import { inspect }  from 'util'
 
 const BUILD_START = 'Building Electron application'
 const BUILD_FAILED = 'Failed to build application'

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -35,7 +35,7 @@ const onBuildSuccess = (config, env, warnings) => {
 
 const onBuildError = error => {
   stopSpinner(BUILD_FAILED, false)
-  log(chalk.grey(Util.inspect(error)))
+  log(chalk.grey(inspect(error)))
   process.stdin.end()
   process.kill(process.pid)
 }

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -7,6 +7,7 @@ import { bundle } from 'builder/bundle'
 import { watch } from 'builder/watcher'
 import { source, sourcePath, destinationPath } from 'utils'
 import { log, warn, startSpinner, stopSpinner } from 'utils/logger'
+import * as Util from "node/util";
 
 const BUILD_START = 'Building Electron application'
 const BUILD_FAILED = 'Failed to build application'
@@ -34,7 +35,7 @@ const onBuildSuccess = (config, env, warnings) => {
 
 const onBuildError = error => {
   stopSpinner(BUILD_FAILED, false)
-  log(chalk.grey(error))
+  log(chalk.grey(Util.inspect(error)))
   process.stdin.end()
   process.kill(process.pid)
 }


### PR DESCRIPTION
Hello, 

When launching bozon start, if something go wrong (typescript compilation for example) we obtain the following message on the output

> [bozon] Failed to build application ✖
> [bozon] [object Object]

Don't you think that using something like Util.inspect to display the content of the object would be more helpful to troubleshoot ?

