### PR TITLE
Allow to write webpack.config.js as an ES module which export default

### DIFF
--- a/src/builder/webpack_config/index.js
+++ b/src/builder/webpack_config/index.js
@@ -84,5 +84,8 @@ export default class WebpackConfig {
     this.config = fs.existsSync(configFile)
       ? __non_webpack_require__(configFile)
       : {}
+    if (this.config.__esModule && this.config.default) {
+      this.config = this.config.default;
+    }
   }
 }


### PR DESCRIPTION
While modernizing a project that now leverages ESM, I needed to declare my webpack.config.js as an ES module too 

This PR allows to do it.

Simply write the webpack.config.js in this form 
`
const webpackConfig = {
  // code here
};

export default webpackConfig;
`